### PR TITLE
Don't Rely on CrystaX for OpenSSL's Android.mk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,6 @@ if [[ ! -e Lib/site-packages/README ]]; then
 fi
 cd ${ROOT}
 
-OLD_OPENSSL_VERSION=1.0.1p
 OPENSSL_VERSION=1.0.2q
 OPENSSL_GIT_TAG=OpenSSL_1_0_2q
 
@@ -126,7 +125,7 @@ if [[ ! -e ${NDK_PATH}/sources/openssl/${OPENSSL_VERSION}/include/openssl/openss
     rm -rf ${NDK_PATH}/sources/openssl/${OPENSSL_VERSION}
   fi
   mkdir ${NDK_PATH}/sources/openssl/${OPENSSL_VERSION}
-  cp ${NDK_PATH}/sources/openssl/${OLD_OPENSSL_VERSION}/Android.mk ${NDK_PATH}/sources/openssl/${OPENSSL_VERSION}
+  cp ${ROOT}/openssl/Android.mk ${NDK_PATH}/sources/openssl/${OPENSSL_VERSION}
 
   ${NDK_PATH}/build/tools/build-target-openssl.sh --ndk_dir=${NDK_PATH} --abis=armeabi,armeabi-v7a,armeabi-v7a-hard,arm64-v8a,x86,x86_64,mips,mips64 $(pwd)/cpython/openssl
 fi

--- a/openssl/Android.mk
+++ b/openssl/Android.mk
@@ -1,0 +1,25 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := opencrypto_shared
+LOCAL_SRC_FILES := libs/$(TARGET_ARCH_ABI)/libcrypto.so
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := opencrypto_static
+LOCAL_SRC_FILES := libs/$(TARGET_ARCH_ABI)/libcrypto.a
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := openssl_shared
+LOCAL_SRC_FILES := libs/$(TARGET_ARCH_ABI)/libssl.so
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := openssl_static
+LOCAL_SRC_FILES := libs/$(TARGET_ARCH_ABI)/libssl.a
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+include $(PREBUILT_STATIC_LIBRARY)


### PR DESCRIPTION
This bundles OpenSSL's ```Android.mk``` with the project so it doesn't rely on CrystaX for it.